### PR TITLE
fix: use bundler moduleResolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "strictFunctionTypes": true,
     "sourceMap": true,
     "target": "ES2020",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "module": "ESNext",
     "resolveJsonModule": true
   }


### PR DESCRIPTION
## What

Changes `moduleResolution` from `"Node"` to `"bundler"` in the shared `@txo/tsconfig`.

## Why

`moduleResolution: "Node"` resolves to the legacy `node10` algorithm, which:

1. **Cannot read package `exports` subpaths** — breaking type resolution for modern dependencies. Concretely, `typescript-eslint` v8.61+ ships `.d.ts` files that import from the `@typescript-eslint/utils/ts-eslint` subpath export, which fails under `node10` (`error TS2307`).
2. **Is deprecated in TypeScript 6** — emits `error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0`.

`"bundler"` resolves both and is the natural pairing for the existing `module: "ESNext"` (switching to `Node16`/`NodeNext` would also force a `module` change and impose import-extension rules — more disruptive).

The CJS variant `@txo/tsconfig-cjs` already uses `Node16`/`Node16` and is unaffected.

## Validation

Verified against `eslint-config-txo-app-nextjs` (on its TypeScript 6 branch): with this change applied and the consumer's local `moduleResolution` override removed, `build`, `type-check`, `lint`, and `test` all pass.

Also validated against the other repos that consume `@txo/tsconfig@^2.0.0` (the `eslint-config-txo-*` package family and `asa-source-available-org-lambda`): applied the `bundler` change to each and re-ran their `type-check`, `build`, and `lint` — no new failures were introduced. Consumers that currently override `moduleResolution` locally can drop that override once this is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
